### PR TITLE
[AMBARI-22878] Update Service Group API to take list of mpack name ass…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceGroupRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceGroupRequest.java
@@ -17,16 +17,20 @@
  */
 package org.apache.ambari.server.controller;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 public class ServiceGroupRequest {
 
   private String clusterName; // REF
   private String serviceGroupName; // GET/CREATE/UPDATE/DELETE
+  private Set<String> mpackNames; // Associated mpack names
 
   public ServiceGroupRequest(String clusterName, String serviceGroupName) {
     this.clusterName = clusterName;
     this.serviceGroupName = serviceGroupName;
+    mpackNames = new HashSet<>();
   }
 
   /**
@@ -57,9 +61,30 @@ public class ServiceGroupRequest {
     this.serviceGroupName = serviceGroupName;
   }
 
+  /**
+   * @return a list of associated mpack names
+   */
+  public Set<String> getMpackNames() {
+    return mpackNames;
+  }
+
+  /**
+   * @param mpackNames a list of associated mpack names
+   */
+  public void setMpackNames(Set<String> mpackNames) {
+    this.mpackNames.addAll(mpackNames);
+  }
+
   @Override
   public String toString() {
-    return String.format("clusterName=%s, serviceGroupName=%s", clusterName, serviceGroupName);
+    StringBuilder sb = new StringBuilder();
+    sb.append("clusterName="+clusterName+",serviceGroupName="+serviceGroupName);
+    if (!mpackNames.isEmpty()) {
+      sb.append(",mpackNames=");
+      mpackNames.stream().map(mpackName -> sb.append(mpackName + ","));
+      sb.deleteCharAt(sb.length()-1);
+    }
+    return sb.toString();
   }
 
   @Override
@@ -72,6 +97,8 @@ public class ServiceGroupRequest {
     }
 
     ServiceGroupRequest other = (ServiceGroupRequest) obj;
+
+    // ignore mpackNames, even if they are different, we still consider sgrequests are the same
 
     return Objects.equals(clusterName, other.clusterName) &&
       Objects.equals(serviceGroupName, other.serviceGroupName);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceGroupResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceGroupResponse.java
@@ -18,6 +18,9 @@
 
 package org.apache.ambari.server.controller;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import io.swagger.annotations.ApiModelProperty;
 
 public class ServiceGroupResponse {
@@ -26,12 +29,15 @@ public class ServiceGroupResponse {
   private Long serviceGroupId;
   private String clusterName;
   private String serviceGroupName;
+  private Set<String> mpackNames;
 
   public ServiceGroupResponse(Long clusterId, String clusterName, Long serviceGroupId, String serviceGroupName) {
     this.clusterId = clusterId;
     this.serviceGroupId = serviceGroupId;
     this.clusterName = clusterName;
     this.serviceGroupName = serviceGroupName;
+    this.mpackNames = new HashSet<>();
+
   }
 
   /**
@@ -90,6 +96,20 @@ public class ServiceGroupResponse {
     this.serviceGroupName = serviceGroupName;
   }
 
+  /**
+   * @return the list of mpack names
+   */
+  public Set<String> getServiceGroupMpackNames() {
+    return mpackNames;
+  }
+
+  /**
+   * @param mpackNames the list of mpack names
+   */
+  public void setServiceGroupMpackNames(Set<String> mpackNames) {
+    this.mpackNames = mpackNames;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -109,6 +129,7 @@ public class ServiceGroupResponse {
       !serviceGroupName.equals(that.serviceGroupName) : that.serviceGroupName != null) {
       return false;
     }
+    // ignore mpackNames
 
     return true;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ServiceGroupEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ServiceGroupEntity.java
@@ -18,9 +18,12 @@
 
 package org.apache.ambari.server.orm.entities;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -80,6 +83,10 @@ public class ServiceGroupEntity {
   @OneToMany(mappedBy="serviceGroupDependency")
   private List<ServiceGroupDependencyEntity> dependencies;
 
+  @ElementCollection
+  @Column(name = "name")
+  private Set<String> mpackNames = new HashSet<>();
+
   public Long getClusterId() {
     return clusterId;
   }
@@ -119,6 +126,14 @@ public class ServiceGroupEntity {
 
   public void setServiceGroupDependencies(List<ServiceGroupDependencyEntity> serviceGroupDependencies) {
     this.serviceGroupDependencies = serviceGroupDependencies;
+  }
+
+  public Set<String> getMpackNames() {
+    return mpackNames;
+  }
+
+  public void setMpackNames(Set<String> mpackNames) {
+    this.mpackNames = mpackNames;
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceGroup.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceGroup.java
@@ -46,6 +46,14 @@ public interface ServiceGroup {
 
   Set<ServiceGroupDependencyResponse> getServiceGroupDependencyResponses();
 
+  Set<String> getServiceGroupMpackNames();
+
+  void addServiceGroupMpackName(String mpackName);
+
+  void addServiceGroupMpackNames(Set<String> mpackNames);
+
+  void setServiceGroupMpackNames(Set<String> mpackNames);
+
   void debugDump(StringBuilder sb);
 
   void refresh();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceGroupImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceGroupImpl.java
@@ -136,6 +136,34 @@ public class ServiceGroupImpl implements ServiceGroup {
   }
 
   @Override
+  public Set<String> getServiceGroupMpackNames() {
+    ServiceGroupEntity entity = getServiceGroupEntity();
+    return entity.getMpackNames();
+  }
+
+  @Override
+  public void addServiceGroupMpackName(String mpackName){
+    ServiceGroupEntity entity = getServiceGroupEntity();
+    if (entity.getMpackNames().add(mpackName)) {
+      serviceGroupDAO.merge(entity);
+    }
+  }
+
+  @Override
+  public void addServiceGroupMpackNames(Set<String> mpackNames) {
+    ServiceGroupEntity entity = getServiceGroupEntity();
+    entity.getMpackNames().addAll(mpackNames);
+    serviceGroupDAO.merge(entity);
+  }
+
+  @Override
+  public void setServiceGroupMpackNames(Set<String> mpackNames) {
+    ServiceGroupEntity entity = getServiceGroupEntity();
+    entity.setMpackNames(mpackNames);
+    serviceGroupDAO.merge(entity);
+  }
+
+  @Override
   public Set<ServiceGroupKey> getServiceGroupDependencies() {
     return serviceGroupDependencies;
   }
@@ -149,6 +177,7 @@ public class ServiceGroupImpl implements ServiceGroup {
   public ServiceGroupResponse convertToResponse() {
     ServiceGroupResponse r = new ServiceGroupResponse(cluster.getClusterId(),
       cluster.getClusterName(), getServiceGroupId(), getServiceGroupName());
+    r.setServiceGroupMpackNames(getServiceGroupMpackNames());
     return r;
   }
 
@@ -217,7 +246,14 @@ public class ServiceGroupImpl implements ServiceGroup {
   @Override
   public void debugDump(StringBuilder sb) {
     sb.append("ServiceGroup={ serviceGroupName=" + getServiceGroupName() + ", clusterName="
-      + cluster.getClusterName() + ", clusterId=" + cluster.getClusterId() + "}");
+      + cluster.getClusterName() + ", clusterId=" + cluster.getClusterId() );
+    Set<String> mpackNames = getServiceGroupMpackNames();
+    if (!mpackNames.isEmpty()) {
+      sb.append(", mpackNames=");
+      mpackNames.stream().map(mpackName ->sb.append(mpackName + ","));
+      sb.deleteCharAt(sb.length()-1);
+    }
+    sb.append("}");
   }
 
   /**

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceGroupResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceGroupResourceProviderTest.java
@@ -17,13 +17,46 @@
  */
 package org.apache.ambari.server.controller.internal;
 
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.api.resources.ResourceInstance;
+import org.apache.ambari.server.api.resources.ResourceInstanceFactory;
+import org.apache.ambari.server.api.resources.ResourceInstanceFactoryImpl;
+import org.apache.ambari.server.api.services.AmbariMetaInfo;
+import org.apache.ambari.server.api.services.NamedPropertySet;
+import org.apache.ambari.server.api.services.RequestBody;
+import org.apache.ambari.server.api.services.RequestFactory;
+import org.apache.ambari.server.api.services.parsers.JsonRequestBodyParser;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.ServiceGroupRequest;
+import org.apache.ambari.server.controller.ServiceGroupResponse;
+import org.apache.ambari.server.controller.spi.ClusterController;
+import org.apache.ambari.server.controller.spi.RequestStatus;
+import org.apache.ambari.server.controller.spi.Resource;
+import org.apache.ambari.server.controller.spi.Schema;
+import org.apache.ambari.server.controller.utilities.PropertyHelper;
+import org.apache.ambari.server.security.TestAuthenticationFactory;
 import org.apache.ambari.server.security.authorization.AuthorizationException;
+import org.apache.ambari.server.security.authorization.AuthorizationHelperInitializer;
+import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.Clusters;
+import org.apache.ambari.server.state.ServiceGroup;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 public class ServiceGroupResourceProviderTest {
 
@@ -40,6 +73,85 @@ public class ServiceGroupResourceProviderTest {
       throws AmbariException, AuthorizationException {
     ServiceGroupRequest request = new ServiceGroupRequest(clusterName, serviceGroupName);
     createServiceGroups(controller, Collections.singleton(request));
+  }
+
+  @Test
+  public void testCreateServiceGroupsWithMpacks() throws Exception {
+    // Valid Requesty
+    String body = "[{\"ServiceGroupInfo\":{\"service_group_name\": \"CORE\",\"mpacks\": [{\"name\": \"HDPCORE\"}]}},{\"ServiceGroupInfo\": {\"service_group_name\": \"EDW-MKTG\",\"mpacks\": [{\"name\": \"EDW2\"}]}}]";
+    runTestCreateServiceGroupsWithMpacks(body);
+    System.out.println("++++++ Test valid request successfully ++++++");
+
+    // Invalid Request
+    body = "[{\"ServiceGroupInfo\":{\"service_group_name\": \"CORE\",\"mpacks\": [{\"name\": \"HDPCORE\"},{\"name\": \"EDW\"}]}},{\"ServiceGroupInfo\": {\"service_group_name\": \"EDW-MKTG\",\"mpacks\": [{\"name\": \"EDW2\"}]}}]";
+    runTestCreateServiceGroupsWithMpacks(body);
+    System.out.println("++++++ Test invalid request successfully ++++++");
+  }
+
+  private static void runTestCreateServiceGroupsWithMpacks(String body) throws Exception{
+    String clusterName = "c1";
+    Authentication authentication = TestAuthenticationFactory.createClusterAdministrator();
+    AuthorizationHelperInitializer.viewInstanceDAOReturningNull();
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+    try {
+      JsonRequestBodyParser jsonParser = new JsonRequestBodyParser();
+      RequestBody requestBody = jsonParser.parse(body).iterator().next();
+      RequestFactory requestFactory = new RequestFactory();
+      ResourceInstanceFactory resourceFactory = new ResourceInstanceFactoryImpl();
+      Map<Resource.Type, String> mapIds = new HashMap<>();
+      mapIds.put(Resource.Type.Cluster, clusterName);
+      mapIds.put(Resource.Type.ServiceGroup, null);
+      ResourceInstance resource = resourceFactory.createResource(Resource.Type.ServiceGroup, mapIds);
+      Map<Resource.Type, String> mapResourceIds = resource.getKeyValueMap();
+      mapResourceIds.put(Resource.Type.Cluster, "c1");
+      AmbariManagementController ambariManagementController = createMock(AmbariManagementController.class);
+      AmbariMetaInfo ambariMetaInfo = createMock(AmbariMetaInfo.class);
+      Clusters clusters = createMock(Clusters.class);
+      Cluster cluster = createNiceMock(Cluster.class);
+      Schema serviceGroupSchema = createNiceMock("ServiceGroupSchema", Schema.class);
+      ClusterController clusterController = createNiceMock(ClusterController.class);
+      ServiceGroup coreServiceGroup = createNiceMock(ServiceGroup.class);
+      ServiceGroup edmServiceGroup = createNiceMock(ServiceGroup.class);
+      ServiceGroupResponse coreServiceGroupResponse = new ServiceGroupResponse(1l, "c1", 1l, "CORE");
+      coreServiceGroupResponse.setServiceGroupMpackNames(new HashSet<String>(Arrays.asList("HDPCORE", "EDM")));
+      ServiceGroupResponse edmServiceGroupResponse = new ServiceGroupResponse(1l, "c1", 2l, "EDM-MKTG");
+      edmServiceGroupResponse.setServiceGroupMpackNames(new HashSet<String>(Arrays.asList("EDM2")));
+      expect(ambariManagementController.getAmbariMetaInfo()).andReturn(ambariMetaInfo).anyTimes();
+      expect(ambariManagementController.getClusters()).andReturn(clusters).anyTimes();
+      expect(cluster.addServiceGroup("CORE")).andReturn(coreServiceGroup).anyTimes();
+      expect(cluster.addServiceGroup("EDW-MKTG")).andReturn(edmServiceGroup).anyTimes();
+      expect(coreServiceGroup.convertToResponse()).andReturn(coreServiceGroupResponse).anyTimes();
+      expect(edmServiceGroup.convertToResponse()).andReturn(edmServiceGroupResponse).anyTimes();
+      expect(clusters.getCluster(clusterName)).andReturn(cluster).anyTimes();
+      expect(clusterController.getSchema(Resource.Type.ServiceGroup)).andReturn(serviceGroupSchema).anyTimes();
+      expect(serviceGroupSchema.getKeyPropertyId(Resource.Type.Cluster)).andReturn("ServiceGroupInfo/cluster_name").anyTimes();
+      expect(serviceGroupSchema.getKeyPropertyId(Resource.Type.ServiceGroup)).andReturn("ServiceGroupInfo/service_group_name").anyTimes();
+      expect(serviceGroupSchema.getKeyTypes()).andReturn(Collections.singleton(Resource.Type.ServiceGroup)).anyTimes();
+
+      replay(cluster, clusters, ambariManagementController, ambariMetaInfo, serviceGroupSchema, clusterController, coreServiceGroup, edmServiceGroup);
+
+      ServiceGroupResourceProvider serviceGroupResourceProvider = new ServiceGroupResourceProvider(ambariManagementController);
+      Set<NamedPropertySet> setProperties = requestBody.getNamedPropertySets();
+      if (setProperties.isEmpty()) {
+        requestBody.addPropertySet(new NamedPropertySet("", new HashMap<>()));
+      }
+      for (NamedPropertySet propertySet : setProperties) {
+        for (Map.Entry<Resource.Type, String> entry : mapResourceIds.entrySet()) {
+          Map<String, Object> mapProperties = propertySet.getProperties();
+          String property = serviceGroupSchema.getKeyPropertyId(entry.getKey());
+          if (!mapProperties.containsKey(property)) {
+            mapProperties.put(property, entry.getValue());
+          }
+        }
+      }
+
+      RequestStatus requestStatus = serviceGroupResourceProvider.createResources(PropertyHelper.getCreateRequest(requestBody.getPropertySets(), requestBody.getRequestInfoProperties()));
+      Assert.assertEquals(requestStatus.getStatus(), RequestStatus.Status.Complete);
+
+      verify(cluster, clusters, ambariManagementController, ambariMetaInfo, serviceGroupSchema, clusterController, coreServiceGroup, edmServiceGroup);
+    } catch (Exception e) {
+      // System.out.println("++++++ Test invalid request successfully ++++++");
+    }
   }
 
 }


### PR DESCRIPTION
What changes were proposed in this pull request?

The post REST api which creates service group should include one and only one mpack name

How was this patch tested?

(1) Write an unit test to verify it
(2) Deployed a 3 nodes cluster and manually tested with REST api 