### PR TITLE
[Ambari-22990] Provide Bootstrap test connection feature

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/rest/BootStrapResource.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/rest/BootStrapResource.java
@@ -56,6 +56,7 @@ public class BootStrapResource {
   public static void init(BootStrapImpl instance) {
     bsImpl = instance;
   }
+
   /**
    * Run bootstrap on a list of hosts.
    * @response.representation.200.doc
@@ -66,13 +67,15 @@ public class BootStrapResource {
    * @throws Exception
    */
   @POST @ApiIgnore // until documented
+  @Path("/{validations}")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-  public BSResponse bootStrap(SshHostInfo sshInfo, @Context UriInfo uriInfo) {
+  public BSResponse bootStrap(SshHostInfo sshInfo, @PathParam("validations") String validations,
+                              @Context UriInfo uriInfo) {
     
     normalizeHosts(sshInfo);
 
-    BSResponse resp = bsImpl.runBootStrap(sshInfo);
+    BSResponse resp = bsImpl.runBootStrap(sshInfo, validations == null ? false : true);
 
     return resp;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/bootstrap/BSHostStatus.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/bootstrap/BSHostStatus.java
@@ -38,6 +38,8 @@ public class BSHostStatus {
   @XmlElement
   private String statusCode;
   @XmlElement
+  private String error;
+  @XmlElement
   private String statusAction;
   @XmlElement
   private String log;
@@ -73,6 +75,14 @@ public class BSHostStatus {
   
   public void setStatusCode(String code) {
     statusCode = code;
+  }
+
+  public String getError() {
+    return this.error;
+  }
+
+  public void setError(String error) {
+    this.error = error;
   }
   
   public String getStatusAction() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/bootstrap/BSHostStatusCollector.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/bootstrap/BSHostStatusCollector.java
@@ -98,6 +98,10 @@ class BSHostStatusCollector {
           while (null != (line = reader.readLine())) {
             if (line.startsWith("tcgetattr:") || line.startsWith("tput:"))
               continue;
+            if (line.startsWith("ERROR MESSAGE:") && !status.getStatusCode().equals("0")) {
+              // Remove "ERROR MESSAGE:" string
+              status.setError(line.substring(line.indexOf("ERROR MESSAGE:")+(new String("ERROR MESSAGE: ")).length()));
+            }
 
             if (0 != sb.length() || 0 == line.length())
               sb.append('\n');

--- a/ambari-server/src/main/java/org/apache/ambari/server/bootstrap/BSRunner.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/bootstrap/BSRunner.java
@@ -61,11 +61,12 @@ class BSRunner extends Thread {
   private final String clusterOsFamily;
   private String projectVersion;
   private int serverPort;
+  private boolean validationInstance;
 
   public BSRunner(BootStrapImpl impl, SshHostInfo sshHostInfo, String bootDir,
       String bsScript, String agentSetupScript, String agentSetupPassword,
       int requestId, long timeout, String hostName, boolean isVerbose, String clusterOsFamily,
-      String projectVersion, int serverPort)
+      String projectVersion, int serverPort, boolean validationInstance)
   {
     this.requestId = requestId;
     this.sshHostInfo = sshHostInfo;
@@ -85,6 +86,7 @@ class BSRunner extends Thread {
     status.setLog("RUNNING");
     status.setStatus(BSStat.RUNNING);
     bsImpl.updateStatus(requestId, status);
+    this.validationInstance = validationInstance;
   }
 
   /**
@@ -202,9 +204,9 @@ class BSRunner extends Thread {
        sshPort = DEFAULT_SSHPORT;
     }
 
-    String command[] = new String[13];
+    String command[] = new String[14];
     BSStat stat = BSStat.RUNNING;
-    String scriptlog = "";
+    StringBuilder scriptlog = new StringBuilder();
     try {
       createRunDir();
       handle = scheduler.scheduleWithFixedDelay(statusCollector,
@@ -242,6 +244,7 @@ class BSRunner extends Thread {
       command[10] = this.serverPort+"";
       command[11] = userRunAs;
       command[12] = (this.passwordFile==null) ? "null" : this.passwordFile.toString();
+      command[13] = String.valueOf(this.validationInstance);
 
       Map<String, String> envVariables = new HashMap<>();
 
@@ -261,7 +264,8 @@ class BSRunner extends Thread {
           requestIdDir + " user=" + user + " sshPort=" + sshPort + " keyfile=" + this.sshKeyFile +
           " passwordFile " + this.passwordFile + " server=" + this.ambariHostname +
           " version=" + projectVersion + " serverPort=" + this.serverPort + " userRunAs=" + userRunAs +
-          " timeout=" + bootstrapTimeout / 1000);
+          " timeout=" + bootstrapTimeout / 1000 +
+          " validation=" + String.valueOf(this.validationInstance));
 
       envVariables.put("AMBARI_PASSPHRASE", agentSetupPassword);
       if (this.verbose)
@@ -282,17 +286,17 @@ class BSRunner extends Thread {
 
       Process process = pb.start();
 
+      StringBuilder logInfoMessage = new StringBuilder(validationInstance ? "Validation" : "Bootstrap");
       try {
-        String logInfoMessage = "Bootstrap output, log="
-              + bootStrapErrorFilePath + " " + bootStrapOutputFilePath + " at " + this.ambariHostname;
-        LOG.info(logInfoMessage);
+        logInfoMessage.append(" output, log=").append(bootStrapErrorFilePath).append(" ").append(bootStrapOutputFilePath).append(" at ").append(ambariHostname);
+        LOG.info(logInfoMessage.toString());
 
         int exitCode = 1;
         boolean timedOut = false;
         if (waitForProcessTermination(process, bootstrapTimeout)){
           exitCode = process.exitValue();
         } else {
-          LOG.warn("Bootstrap process timed out. It will be destroyed.");
+          LOG.warn(logInfoMessage.append(" process timed out. It will be destroyed.").toString());
           process.destroy();
           timedOut = true;
         }
@@ -305,14 +309,14 @@ class BSRunner extends Thread {
         } catch(IOException io) {
           LOG.info("Error in reading files ", io);
         }
-        scriptlog = outMesg + "\n\n" + errMesg;
+        scriptlog.append(outMesg).append("\n\n").append(errMesg);
         if (timedOut) {
-          scriptlog += "\n\n Bootstrap process timed out. It was destroyed.";
+          scriptlog.append("\n\n ").append(validationInstance ? "Validation" : "Bootstrap").append(" process timed out. It was destroyed.");
         }
-        LOG.info("Script log Mesg " + scriptlog);
+        LOG.info("Script log Mesg " + scriptlog.toString());
         if (exitCode != 0) {
           stat = BSStat.ERROR;
-          interuptSetupAgent(99, scriptlog);
+          interuptSetupAgent(99, scriptlog.toString());
         } else {
           stat = BSStat.SUCCESS;
         }
@@ -359,8 +363,10 @@ class BSRunner extends Thread {
         if (handle != null) {
           handle.cancel(true);
         }
-        /* schedule a last update */
-        scheduler.schedule(new BSStatusCollector(), 0, TimeUnit.SECONDS);
+        if (!validationInstance) {
+          /* schedule a last update */
+          scheduler.schedule(new BSStatusCollector(), 0, TimeUnit.SECONDS);
+        }
         scheduler.shutdownNow();
         try {
           scheduler.awaitTermination(10, TimeUnit.SECONDS);
@@ -392,7 +398,7 @@ class BSRunner extends Thread {
       // creating new status instance to avoid modifying exposed object
       BootStrapStatus newStat = new BootStrapStatus();
       newStat.setHostsStatus(hostStatusList);
-      newStat.setLog(scriptlog);
+      newStat.setLog(scriptlog.toString());
       newStat.setStatus(stat);
 
       // Remove private ssh key after bootstrap is complete

--- a/ambari-server/src/main/java/org/apache/ambari/server/bootstrap/BootStrapImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/bootstrap/BootStrapImpl.java
@@ -101,7 +101,7 @@ public class BootStrapImpl {
     }
   }
 
-  public  synchronized BSResponse runBootStrap(SshHostInfo info) {
+  public  synchronized BSResponse runBootStrap(SshHostInfo info, boolean validate) {
     BSResponse response = new BSResponse();
     /* Run some checks for ssh host */
     LOG.info("BootStrapping hosts " + info.hostListAsString());
@@ -127,7 +127,7 @@ public class BootStrapImpl {
     } else {
       bsRunner = new BSRunner(this, info, bootStrapDir.toString(),
           bootScript, bootSetupAgentScript, bootSetupAgentPassword, requestId, 0L,
-          this.masterHostname, info.isVerbose(), this.clusterOsFamily, this.projectVersion, this.serverPort);
+          this.masterHostname, info.isVerbose(), this.clusterOsFamily, this.projectVersion, this.serverPort, validate);
       bsRunner.start();
       response.setStatus(BSRunStat.OK);
       response.setLog("Running Bootstrap now.");

--- a/ambari-server/src/test/java/org/apache/ambari/server/bootstrap/BootStrapResourceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/bootstrap/BootStrapResourceTest.java
@@ -68,7 +68,7 @@ public class BootStrapResourceTest extends JerseyTest {
     protected void configure() {
       BootStrapImpl bsImpl = mock(BootStrapImpl.class);
       when(bsImpl.getStatus(0)).thenReturn(generateDummyBSStatus());
-      when(bsImpl.runBootStrap(any(SshHostInfo.class))).thenReturn(generateBSResponse());
+      when(bsImpl.runBootStrap(any(SshHostInfo.class), false)).thenReturn(generateBSResponse());
       bind(BootStrapImpl.class).toInstance(bsImpl);
       requestStaticInjection(BootStrapResource.class);
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/bootstrap/BootStrapTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/bootstrap/BootStrapTest.java
@@ -94,7 +94,7 @@ public class BootStrapTest extends TestCase {
     info.setHosts(hosts);
     info.setUser("user");
     info.setPassword("passwd");
-    BSResponse response = impl.runBootStrap(info);
+    BSResponse response = impl.runBootStrap(info, false);
     LOG.info("Response id from bootstrap " + response.getRequestId());
     /* do a query */
     BootStrapStatus status = impl.getStatus(response.getRequestId());
@@ -172,7 +172,7 @@ public class BootStrapTest extends TestCase {
     info.setUser("user");
     info.setUserRunAs("root");
     info.setPassword("passwd");
-    BSResponse response = impl.runBootStrap(info);
+    BSResponse response = impl.runBootStrap(info, false);
     long requestId = response.getRequestId();
     LOG.info("Response id from bootstrap " + requestId);
       /* create failed done file for host2 */


### PR DESCRIPTION
A utility to verify connectivity of hosts before they are registered to Ambari server

This change is to verify the connectivity of hosts before they are registered to Ambari server. The Ambari server invokes bootstrap.py to do ssh login to all the interested hosts and get the status of connectivity after verification and return to the Rest API client.
(Please fill in changes proposed in this fix)

## How was this patch tested?

Manually tested:

Request:

POST http://c6801.ambari.apache.org:8080/api/v1/bootstrap/validations

{
"verbose": true,
"sshKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBAAKCAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzI\nw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoP\nkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2\nhMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NO\nTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcW\nyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQIBIwKCAQEA4iqWPJXtzZA68mKd\nELs4jJsdyky+ewdZeNds5tjcnHU5zUYE25K+ffJED9qUWICcLZDc81TGWjHyAqD1\nBw7XpgUwFgeUJwUlzQurAv+/ySnxiwuaGJfhFM1CaQHzfXphgVml+fZUvnJUTvzf\nTK2Lg6EdbUE9TarUlBf/xPfuEhMSlIE5keb/Zz3/LUlRg8yDqz5w+QWVJ4utnKnK\niqwZN0mwpwU7YSyJhlT4YV1F3n4YjLswM5wJs2oqm0jssQu/BT0tyEXNDYBLEF4A\nsClaWuSJ2kjq7KhrrYXzagqhnSei9ODYFShJu8UWVec3Ihb5ZXlzO6vdNQ1J9Xsf\n4m+2ywKBgQD6qFxx/Rv9CNN96l/4rb14HKirC2o/orApiHmHDsURs5rUKDx0f9iP\ncXN7S1uePXuJRK/5hsubaOCx3Owd2u9gD6Oq0CsMkE4CUSiJcYrMANtx54cGH7Rk\nEjFZxK8xAv1ldELEyxrFqkbE4BKd8QOt414qjvTGyAK+OLD3M2QdCQKBgQDtx8pN\nCAxR7yhHbIWT1AH66+XWN8bXq7l3RO/ukeaci98JfkbkxURZhtxV/HHuvUhnPLdX\n3TwygPBYZFNo4pzVEhzWoTtnEtrFueKxyc3+LjZpuo+mBlQ6ORtfgkr9gBVphXZG\nYEzkCD3lVdl8L4cw9BVpKrJCs1c5taGjDgdInQKBgHm/fVvv96bJxc9x1tffXAcj\n3OVdUN0UgXNCSaf/3A/phbeBQe9xS+3mpc4r6qvx+iy69mNBeNZ0xOitIjpjBo2+\ndBEjSBwLk5q5tJqHmy/jKMJL4n9ROlx93XS+njxgibTvU6Fp9w+NOFD/HvxB3Tcz\n6+jJF85D5BNAG3DBMKBjAoGBAOAxZvgsKN+JuENXsST7F89Tck2iTcQIT8g5rwWC\nP9Vt74yboe2kDT531w8+egz7nAmRBKNM751U/95P9t88EDacDI/Z2OwnuFQHCPDF\nllYOUI+SpLJ6/vURRbHSnnn8a/XG+nzedGH5JGqEJNQsz+xT2axM0/W/CRknmGaJ\nkda/AoGANWrLCz708y7VYgAtW2Uf1DPOIYMdvo6fxIB5i9ZfISgcJ/bbCUkFrhoH\n+vq/5CIWxCPp0f85R4qxxQ5ihxJ0YDQT9Jpx4TMss4PSavPaBH3RXow5Ohe+bYoQ\nNE5OgEXk2wVfZczCZpigBKbKZHNYcelXtTt/nP3rsCuGcM4h53s=\n-----END RSA PRIVATE KEY-----\n",
"hosts": [
"c6804.ambari.apache.org",
"c6802.ambari.apache.org"
],
"user": "root",
"sshPort": "22",
"userRunAs": "root"
}

Response:

{
"status": "OK",
"log": "Running Bootstrap now.",
"requestId": 1
}

Then use another existing Rest API to get the status:

Request:

GET http://c6801.ambari.apache.org:8080/api/v1/bootstrap/1

Response:

{
"status": "ERROR",
"hostsStatus": [
{
"hostName": "c6804.ambari.apache.org",
"status": "FAILED",
"statusCode": "255",
"error": "ssh: connect to host c6804.ambari.apache.org port 22: No route to host",
"log": "==========================\nRunning login to the host c6804.ambari.apache.org ...\n==========================\n\nCommand start time 2018-03-02 06:35:27\n\nssh: connect to host c6804.ambari.apache.org port 22: No route to host\nSSH command execution finished\nhost=c6804.ambari.apache.org, exitcode=255\nCommand end time 2018-03-02 06:35:30\n\nERROR: Validation of host c6804.ambari.apache.org fails because it finished with non-zero exit code (255)\nERROR MESSAGE: ssh: connect to host c6804.ambari.apache.org port 22: No route to host\n\nSTDOUT: \nssh: connect to host c6804.ambari.apache.org port 22: No route to host"
},
{
"hostName": "c6802.ambari.apache.org",
"status": "DONE",
"statusCode": "0",
"log": "==========================\nRunning login to the host c6802.ambari.apache.org ...\n==========================\n\nCommand start time 2018-03-02 06:35:27\n\nConnection to c6802.ambari.apache.org closed.\nSSH command execution finished\nhost=c6802.ambari.apache.org, exitcode=0\nCommand end time 2018-03-02 06:35:27\n"
}
],
"log": "\n\nINFO:root:BootStrapping hosts ['c6804.ambari.apache.org', 'c6802.ambari.apache.org'] using /usr/lib/ambari-server/lib/ambari_server cluster primary OS: redhat6 with user 'root'with ssh Port '22' sshKey File /var/run/ambari-server/bootstrap/1/sshKey password File null using tmp dir /var/run/ambari-server/bootstrap/1 ambari: c6801.ambari.apache.org; server_port: 8080; ambari version: 2.0.0.0; user_run_as: root\nINFO:root:Executing parallel connectivity validation\nERROR:root:ERROR: Validation of host c6804.ambari.apache.org fails because it finished with non-zero exit code (255)\nERROR MESSAGE: ssh: connect to host c6804.ambari.apache.org port 22: No route to host\r\n\nSTDOUT: \nssh: connect to host c6804.ambari.apache.org port 22: No route to host\r\n\nINFO:root:Finished parallel connectivity validation\nINFO:root:Finished parallel connectivity validation\n"
}